### PR TITLE
Use Preconnect/Defer and Guard Against Redefinition of SessionController

### DIFF
--- a/django_spire/core/static/django_spire/js/session_controller.js
+++ b/django_spire/core/static/django_spire/js/session_controller.js
@@ -1,10 +1,11 @@
-class SessionController {
-    constructor(session_json) {
-        this.data = JSON.parse(session_json);
-    }
+if (typeof window.SessionController === 'undefined') {
+    window.SessionController = class SessionController {
+        constructor(session_json) {
+            this.data = JSON.parse(session_json);
+        }
 
-    get_data(key, default_value) {
-        return this.data[key] !== undefined ? this.data[key] : default_value;
-    }
-
+        get_data(key, default_value) {
+            return this.data[key] !== undefined ? this.data[key] : default_value;
+        }
+    };
 }

--- a/django_spire/core/templates/django_spire/base/base.html
+++ b/django_spire/core/templates/django_spire/base/base.html
@@ -5,8 +5,6 @@
 <html lang="en" data-theme="{{ theme.mode }}" data-theme-family="{{ theme.family }}">
 <head>
     {% block base_head %}
-        <style>[x-cloak] { display: none !important; }</style>
-
         {% block base_head_title %}
             <title>{{ html_head_title }}</title>
         {% endblock %}
@@ -15,6 +13,8 @@
             <meta charset="UTF-8">
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
             <meta http-equiv="X-UA-Compatible" content="ie=edge">
+            <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+            <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
         {% endblock %}
 
         {% block base_head_additional_meta %}
@@ -46,9 +46,9 @@
             </script>
             <link rel="manifest" href="{% static 'django_spire/favicons/manifest.json' %}">
 
-            <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
-            <script src="https://cdn.jsdelivr.net/npm/echarts@5.4.x/dist/echarts.min.js"></script>
-            <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+            <script defer src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+            <script defer src="https://cdn.jsdelivr.net/npm/echarts@5.4.x/dist/echarts.min.js"></script>
+            <script defer src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
 
             <script src="https://cdnjs.cloudflare.com/ajax/libs/pulltorefreshjs/0.1.22/index.umd.min.js"></script>
 


### PR DESCRIPTION
- `preconnect` tells the browser to start the DNS lookup, TCP handshake, and TLS negotiation with a domain before it actually encounters a resource from that domain. Otherwise, those steps happen sequentially when the browser first hits a `<link>` or `<script>` referencing that origin.
- `defer` on a `<script>` tag means the browser downloads the script in parallel with HTML parsing but delays execution until the HTML is fully parsed. Otherwise, `defer` (and without `async`), a plain `<script>` blocks HTML parsing while it downloads and executes.
- The `session_controller.js` script was being loaded twice (once from `django-spire`'s base template and again from a component or child template in our other projects, so we would get a console error about redefining it), and the second load redefined the class, which was overwriting the first.