### PR TITLE
Password Reset/Update Site Object

### DIFF
--- a/django_spire/auth/templates/django_spire/auth/password_reset_email.html
+++ b/django_spire/auth/templates/django_spire/auth/password_reset_email.html
@@ -5,7 +5,7 @@
 {% block reset_link %}
 {{ protocol }}://{{ domain }}{% url 'django_spire:auth:admin:password_reset_confirmation' uidb64=uid token=token %}
 {% endblock %}
-{% translate 'Your username, in case you’ve forgotten:' %} {{ user.get_username }}
+{% translate "Your username, in case you've forgotten:" %} {{ user.get_username }}
 
 {% translate "Thanks for using our site!" %}
 

--- a/django_spire/core/apps.py
+++ b/django_spire/core/apps.py
@@ -10,3 +10,6 @@ class DjangoSpireConfig(AppConfig):
 
     URLPATTERNS_INCLUDE = 'django_spire.core.urls'
     URLPATTERNS_NAMESPACE = 'core'
+
+    def ready(self) -> None:
+        import django_spire.core.signals  # noqa: F401, PLC0415

--- a/django_spire/core/signals.py
+++ b/django_spire/core/signals.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from django.conf import settings
+from django.contrib.sites.models import Site
+from django.db.models.signals import post_migrate
+from django.dispatch import receiver
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from django.apps import AppConfig
+
+
+@receiver(post_migrate)
+def sync_site_from_settings(sender: type[AppConfig], **kwargs: Any) -> None:
+    if not hasattr(settings, 'DJANGO_SITE_DOMAIN'):
+        return
+
+    site_id = getattr(settings, 'SITE_ID', 1)
+
+    Site.objects.update_or_create(
+        id=site_id,
+        defaults={
+            'domain': settings.DJANGO_SITE_DOMAIN,
+            'name': getattr(settings, 'DJANGO_SITE_NAME', settings.DJANGO_SITE_DOMAIN),
+        }
+    )


### PR DESCRIPTION
We've encountered this issue twice recently due to our `Site` object. 

By default, Django creates a default site named `example.com` with the domain `example.com`.
https://docs.djangoproject.com/en/6.0/ref/contrib/sites/#enabling-the-sites-framework

We've run into this issue using the HTML Renderer where we had to manually set the `Site` object in a staging server. And it is also an issue when a user wants to reset their password. We send them the email, but the URL inside of the email will send them to `example.com/...` where the domain name comes from our `Site` object.

There appears to be two approaches to solve this:
1. Create a migration to create a `Site` object
2. Use a signal to dynamically pull from our environment variables and set it from there

I've opted to do the second approach as it seems more flexible. However, this means, we will have to set `DJANGO_SITE_NAME` and `DJANGO_SITE_DOMAIN` in our `base_settings.py` for each project. For example:
```
DJANGO_SITE_NAME = os.getenv('DJANGO_SITE_NAME', 'Example')
DJANGO_SITE_DOMAIN = os.getenv('DJANGO_SITE_DOMAIN', 'localhost:8000')
```

And then we would have to update the environment variables for each environment that we have (i.e., staging or production) and point to the correct domain name.

I have tested this locally and can confirm it works, but it is tedious.

I can see we set `SITE_ID = 1` in our `base_settings.py`, but I was unable to find anything else related to the `Site` object.

Do we have a better approach, have we seen anything else?