### PR TITLE
Auth: Enforce Password Change on First Login

### DIFF
--- a/django_spire/auth/tests/test_views.py
+++ b/django_spire/auth/tests/test_views.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from django.contrib.auth import get_user
 from django.urls import reverse
+from django.utils import timezone
 
 from django_spire.auth.user.tests.factories import create_user
 from django_spire.core.tests.test_cases import BaseTestCase
@@ -164,6 +165,28 @@ class LoginViewTestCase(BaseTestCase):
             data={'username': 'test\tuser', 'password': 'password'}
         )
         assert response.status_code == 200
+
+    def test_initial_login_redirects_to_password_change(self) -> None:
+        self.user.last_login = None
+        self.user.save()
+        response = self.client.post(
+            reverse('django_spire:auth:admin:login'),
+            data={'username': 'testuser', 'password': 'testpassword123'},
+        )
+
+        assert response.status_code == 302
+        assert response.url == reverse('django_spire:auth:admin:password_change')
+
+    def test_user_has_logged_in_before(self) -> None:
+        self.user.last_login = timezone.now()
+        self.user.save()
+        response = self.client.post(
+            reverse('django_spire:auth:admin:login'),
+            data={'username': 'testuser', 'password': 'testpassword123'},
+        )
+
+        assert response.status_code == 302
+        assert response.url != reverse('django_spire:auth:admin:password_change')
 
 
 class PasswordChangeViewTestCase(BaseTestCase):

--- a/django_spire/auth/views/admin_views.py
+++ b/django_spire/auth/views/admin_views.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from django.contrib.auth import views as auth_views
-from django.urls import reverse_lazy
+from django.contrib.auth import login as auth_login
+from django.http import HttpResponseRedirect
+from django.urls import reverse_lazy, reverse
 
 from django_spire.contrib.form.utils import show_form_errors
 
@@ -12,6 +14,12 @@ class LoginView(auth_views.LoginView):
     def form_invalid(self, form):
         show_form_errors(self.request, form)
         return super().form_invalid(form)
+
+    def form_valid(self, form):
+        if form.get_user().last_login is None:
+            auth_login(self.request, form.get_user())
+            return HttpResponseRedirect(reverse('django_spire:auth:admin:password_change'))
+        return super().form_valid(form)
 
 
 class PasswordChangeView(auth_views.PasswordChangeView):


### PR DESCRIPTION
Implemented:
-  login view form valid change to redirect to password change if the user hasn't logged in before. 
- Added tests to reflect the above change change.