### PR TITLE
V1/wesleyw/spire 192 username email lower

### DIFF
--- a/django_spire/auth/forms.py
+++ b/django_spire/auth/forms.py
@@ -1,6 +1,5 @@
 from django.contrib.auth.forms import AuthenticationForm
-
-from django_spire.auth.user.models import AuthUser
+from django.contrib.auth.models import User
 
 
 class CaseInsensitiveAuthenticationForm(AuthenticationForm):
@@ -9,7 +8,7 @@ class CaseInsensitiveAuthenticationForm(AuthenticationForm):
         username = self.cleaned_data.get("username")
 
         if username:
-            user = AuthUser.objects.filter(
+            user = User.objects.filter(
                 username__iexact=username.lower()
             ).first()
 

--- a/django_spire/auth/forms.py
+++ b/django_spire/auth/forms.py
@@ -1,0 +1,22 @@
+from django.contrib.auth.forms import AuthenticationForm
+
+from django_spire.auth.user.models import AuthUser
+
+
+class CaseInsensitiveAuthenticationForm(AuthenticationForm):
+
+    def clean(self):
+        username = self.cleaned_data.get("username")
+
+        if username:
+            user = AuthUser.objects.filter(
+                username__iexact=username.lower()
+            ).first()
+
+            if user is None:
+                raise self.get_invalid_login_error()
+
+            self.cleaned_data["username"] = user.username
+
+        return super().clean()
+

--- a/django_spire/auth/tests/test_views.py
+++ b/django_spire/auth/tests/test_views.py
@@ -77,7 +77,7 @@ class LoginViewTestCase(BaseTestCase):
             reverse('django_spire:auth:admin:login'),
             data={'username': 'TESTUSER', 'password': 'testpassword123'}
         )
-        assert response.status_code == 200
+        assert response.status_code == 302
 
     def test_login_case_sensitive_password(self) -> None:
         response = self.client.post(

--- a/django_spire/auth/user/forms.py
+++ b/django_spire/auth/user/forms.py
@@ -10,7 +10,7 @@ from django_spire.auth.user.factories import register_new_user
 
 class UserForm(forms.ModelForm):
     def save(self, commit: bool = True):
-        self.instance.username = self.cleaned_data['email']
+        self.instance.username = self.cleaned_data['email'].lower()
         return super().save(commit=commit)
 
     class Meta:

--- a/django_spire/auth/views/admin_views.py
+++ b/django_spire/auth/views/admin_views.py
@@ -5,10 +5,12 @@ from django.contrib.auth import login as auth_login
 from django.http import HttpResponseRedirect
 from django.urls import reverse_lazy, reverse
 
+from django_spire.auth.forms import CaseInsensitiveAuthenticationForm
 from django_spire.contrib.form.utils import show_form_errors
 
 
 class LoginView(auth_views.LoginView):
+    authentication_form = CaseInsensitiveAuthenticationForm
     template_name = 'django_spire/auth/page/login_page.html'
 
     def form_invalid(self, form):
@@ -16,8 +18,9 @@ class LoginView(auth_views.LoginView):
         return super().form_invalid(form)
 
     def form_valid(self, form):
-        if form.get_user().last_login is None:
-            auth_login(self.request, form.get_user())
+        form_user = form.get_user()
+        if form_user.last_login is None:
+            auth_login(self.request, form_user)
             return HttpResponseRedirect(reverse('django_spire:auth:admin:password_change'))
         return super().form_valid(form)
 


### PR DESCRIPTION
Implemented:
- Updated user form to save user with a lowercase username
- Update login view authentication form with a new case sensitive form

Notes:
The new form now also checks if the lowercase entered username is a user in the system. if so then run the regular authentication clean with the username from the system (this is because the base authentication call is case sensitive.). If not then it shows an invalid login error.